### PR TITLE
Fix: non-radio voice transmission not working on 3.1.1 / main:latest

### DIFF
--- a/lua/gspeak/cl_player.lua
+++ b/lua/gspeak/cl_player.lua
@@ -18,6 +18,8 @@ function meta:InitializeGspeak()
 	self:SetNW2VarProxy("Talking", function(ent, key, prev, now)
 		ent:SetTalking(now)
 	end)
+
+	gspeak:RegisterGspeakEntity(self)
 end
 
 function meta:GetAudioSourceRange()


### PR DESCRIPTION
Not sure if this is valid, but it appears that 3.1.1 currently has a bug where default voice transmission doesn't work, but using a radio does.

Looking into it, it looked like the `gspeak_volume_control` hook was related - iteration through `gspeak.gspeakEntities` wasn't occurring, but hot-reloading cl_volume_control.lua would cause it to start processing correctly.

It appears that player entities are not registered anywhere as other entities are, e.g `DefaultInitialize()` in sh_def_ent.lua

This change calls `gspeak:RegisterGspeakEntity(self)` in cl_player.lua `InitializeGspeak()` which appears to solve the problem.

Side note: the `SetHearable()` function also appears to be flooding the console log on the client currently?